### PR TITLE
Add better error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "auto": "^4.8.13",
+    "await-to-js": "^2.1.1",
     "axios": "^0.18.0",
     "lodash": "^4.17.11",
     "pino": "^5.12.5",

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,6 +9,6 @@ export = (app: Application) => {
   const autobot = Autobot.start(app, features);
 
   app.on("pull_request", async context => {
-    autobot.onPullRequestReceived(context);
+    await autobot.onPullRequestReceived(context);
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -942,6 +942,11 @@ auto@^4.8.13:
     typescript-memoize "^1.0.0-alpha.3"
     url-join "^4.0.0"
 
+await-to-js@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/await-to-js/-/await-to-js-2.1.1.tgz#c2093cd5a386f2bb945d79b292817bbc3f41b31b"
+  integrity sha512-CHBC6gQGCIzjZ09tJ+XmpQoZOn4GdWePB4qUweCaKNJ0D3f115YdhmYVTZ4rMVpiJ3cFzZcTYK1VMYEICV4YXw==
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"


### PR DESCRIPTION
So I found this neat library today: https://github.com/scopsy/await-to-js

It really does make dealing with errors easier. 

What do you think @hipstersmoothie? Also, I'm kinda curious what you think about the `onError` hook pattern. I'm not sure about it. 

The hooks don't really map cleanly to the state so reporting hook names feels a little weird. But it's an easy way to tell the plugins what the fail was related to in terms that they'd understand. 
