### PR TITLE
Ensure status is reported correctly when nothing to process

### DIFF
--- a/src/features/fail-if-no-release-labels.ts
+++ b/src/features/fail-if-no-release-labels.ts
@@ -20,7 +20,6 @@ export default class FailIfMissingLabels extends PullRequestPlugin {
   private failed = false;
 
   public apply(prHooks: Hooks["pr"]) {
-    logger.info({ func: this.isMissingRequiredLabels.bind(this) });
     prHooks.shouldSkipAllProcessing.tapPromise(this.name, this.isMissingRequiredLabels.bind(this));
     prHooks.modifySkipStatus.tapPromise(this.name, this.setSkipStatus.bind(this));
   }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,4 @@
-import { ExecutionScope, Hooks } from "./autobot";
+import { ExecutionScope, Hooks, PRContext } from "./autobot";
 
 /**
  * Do not directly extend from this class unless you're
@@ -19,7 +19,7 @@ export abstract class AppPlugin extends Plugin {
 
 export abstract class PullRequestPlugin extends Plugin {
   public static scope = ExecutionScope.PullRequest;
-  abstract apply(hooks: Hooks[ExecutionScope.PullRequest]): void;
+  abstract apply(hooks: Hooks[ExecutionScope.PullRequest], context: PRContext): void;
 }
 
 export type UninitializedPlugin = typeof AppPlugin | typeof PullRequestPlugin;


### PR DESCRIPTION
Ack! It took me forever to figure this out, but it's simple in hindsight.

The bug was, every time a label was removed it would the GitHub status of auto would fail (thanks to `fail-if-no-release-labels`) but then it'd immediately go to passing. 

I didn't have a return in the skip block so it was just going on to the processing phase which sets its own status. 

That brought me to another thing... if there's no plugins actually doing processing then then we definitely don't want to actually start setting a status and stuff for it. If there's no process hook I nixed the processing phase. Yay.

Last somewhat unrelated change that I'm going to utilize later: I started passing the PR context off to each PR plugin's `apply` method. This way a plugin can have a little more info of whether or not it should add hooks and which hooks it should add. 
