### PR TITLE
Always show a status message, fail on multiple labels

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,5 +8,6 @@ module.exports = {
   rules: {
     "@typescript-eslint/explicit-function-return-type": false,
     "@typescript-eslint/no-explicit-any": false,
+    "@typescript-eslint/camelcase": false,
   },
 };

--- a/test/features/block-if-missing-labels.test.ts
+++ b/test/features/block-if-missing-labels.test.ts
@@ -1,0 +1,81 @@
+import { BlockIfMissingLabels, LabelError, ReleaseType } from "../../src/features/block-if-missing-labels";
+
+describe("BlockIfMissingLabels", () => {
+  describe("isMissingRequiredLabels", () => {
+    const context = (...labels: string[]) => ({
+      payload: {
+        pull_request: {
+          labels: labels.map(label => ({ name: label })),
+        },
+      },
+    });
+    let config: object;
+    beforeEach(() => {
+      config = {
+        labels: {
+          major: "major",
+          minor: "minor",
+          patch: "patch",
+          "skip-release": "skip release",
+        },
+        skipReleaseLabels: [],
+      };
+    });
+
+    it("sets the release state to an error if no version labels are found", async () => {
+      const feature = new BlockIfMissingLabels();
+      // @ts-ignore
+      await feature.isMissingRequiredLabels(context(), config);
+      // @ts-ignore
+      expect(feature.releaseState).toBe(LabelError.NoLabels);
+    });
+
+    it("sets the release state to an error if multiple version labels are found", async () => {
+      const feature = new BlockIfMissingLabels();
+      // @ts-ignore
+      await feature.isMissingRequiredLabels(context("major", "patch"), config);
+      // @ts-ignore
+      expect(feature.releaseState).toBe(LabelError.ConflictingLabels);
+    });
+
+    it("sets the release state to major", async () => {
+      const feature = new BlockIfMissingLabels();
+      // @ts-ignore
+      await feature.isMissingRequiredLabels(context("major"), config);
+      // @ts-ignore
+      expect(feature.releaseState).toEqual({
+        type: ReleaseType.Major,
+        skip: false,
+      });
+    });
+    it("sets the release state to minor", async () => {
+      const feature = new BlockIfMissingLabels();
+      // @ts-ignore
+      await feature.isMissingRequiredLabels(context("minor"), config);
+      // @ts-ignore
+      expect(feature.releaseState).toEqual({
+        type: ReleaseType.Minor,
+        skip: false,
+      });
+    });
+    it("sets the release state to patch", async () => {
+      const feature = new BlockIfMissingLabels();
+      // @ts-ignore
+      await feature.isMissingRequiredLabels(context("patch"), config);
+      // @ts-ignore
+      expect(feature.releaseState).toEqual({
+        type: ReleaseType.Patch,
+        skip: false,
+      });
+
+      // It should also be patch if a skip release is set
+      // @ts-ignore
+      await feature.isMissingRequiredLabels(context("skip release"), config);
+      // @ts-ignore
+      expect(feature.releaseState).toEqual({
+        type: ReleaseType.Patch,
+        skip: true,
+      });
+    });
+  });
+});


### PR DESCRIPTION
I think this wraps up phase I of the implementation for autobot. 

Changes in this PR:

- Give an error when multiple version labels are added to a single PR
- Give a useful status about what will happen on merge when the labels are correct
- Adds just a little more test coverage