### PR TITLE
Enable sentry for error tracking

### DIFF
--- a/now.json
+++ b/now.json
@@ -7,7 +7,8 @@
     "NODE_ENV": "production",
     "APP_ID": "@autobot-app-id",
     "WEBHOOK_SECRET": "@autobot-webhook-secret",
-    "PRIVATE_KEY": "@autobot-private-key"
+    "PRIVATE_KEY": "@autobot-private-key",
+    "SENTRY_DSN": "@sentry-dsn"
   },
   "routes": [{ "src": "/", "dest": "/now.js" }]
 }


### PR DESCRIPTION
Probot has a [sentry client built in](https://probot.github.io/docs/deployment/#error-tracking) so all I needed to do is add the dsn to now's secrets and update the config. 